### PR TITLE
Swap .env file copy and key gen steps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,6 @@ Run the following ``composer`` command to install the dependencies:
 composer install
 ```
 
-### Generate an App Key
-
-Run the following command to generate a Laravel application key:
-
-```
-php artisan key:generate
-```
-
 ### Make a Copy of the Example Environment File
 
 Run the following command to use the example environment file
@@ -70,6 +62,14 @@ in your sample app:
 
 ```
 cp .env.example .env
+```
+
+### Generate an App Key
+
+Run the following command to generate a Laravel application key:
+
+```
+php artisan key:generate
 ```
 
 ### Configure your MongoDB Credentials


### PR DESCRIPTION
The key gen step fails if the .env example file hasn't been copied yet, so that step should come first.